### PR TITLE
New event schema, events emitted, tests passing.

### DIFF
--- a/contracts/Moloch.sol
+++ b/contracts/Moloch.sol
@@ -24,10 +24,11 @@ contract Moloch {
     uint256 constant MAX_DILUTION_BOUND = 10**18;
     uint256 constant MAX_NUMBER_OF_SHARES = 10**18;
 
-    event SubmitProposal(uint256 proposalIndex, address indexed delegateKey, address indexed memberAddress, address indexed applicant, uint256 tributeOffered, uint256 sharesRequested);
-    event SubmitVote(uint256 indexed proposalIndex, address indexed delegateKey, address indexed memberAddress, uint8 uintVote);
-    event ProcessProposal(uint256 indexed proposalIndex, address indexed applicant, address indexed memberAddress, uint256 tributeOffered, uint256 sharesRequested, bool didPass);
-    event Ragequit(address indexed memberAddress, uint256 sharesToBurn);
+    event SubmitProposal(uint256 proposalIndex, address indexed delegateKey, address indexed memberAddress, address indexed applicant,uint256 tributeOffered, address tributeToken, uint256 sharesRequested, uint256 paymentRequested, address paymentToken);
+    event SponsorProposal(address indexed delegateKey, address indexed memberAddress, uint256 proposalIndex, uint256 proposalQueueIndex, uint256 startingPeriod);
+    event SubmitVote(uint256 indexed proposalQueueIndex, address indexed delegateKey, address indexed memberAddress, uint8 uintVote);
+    event ProcessProposal(uint256 indexed proposalQueueIndex, address indexed applicant, address indexed memberAddress, uint256 tributeOffered, address tributeToken, uint256 sharesRequested, bool didPass);
+    event Ragequit(address indexed memberAddress, uint256 sharesToBurn, address[] tokenList);
     event CancelProposal(uint256 indexed proposalIndex, address applicantAddress);
     event UpdateDelegateKey(address indexed memberAddress, address newDelegateKey);
     event SummonComplete(address indexed summoner, uint256 shares);
@@ -209,6 +210,8 @@ contract Moloch {
             });
 
         proposals[proposalCount] = proposal;
+        address memberAddress = memberAddressByDelegateKey[msg.sender];
+        emit SubmitProposal(proposalCount, msg.sender, memberAddress, applicant, tributeOffered, tributeToken, sharesRequested, paymentRequested, paymentToken);
         proposalCount += 1;
     }
 
@@ -251,6 +254,7 @@ contract Moloch {
         proposal.flags[0] = true;
 
         proposalQueue.push(proposalId);
+        emit SponsorProposal(msg.sender, memberAddress, proposalId, proposalQueue.length.sub(1), startingPeriod);
     }
 
     function submitVote(uint256 proposalIndex, uint8 uintVote) public onlyDelegate {
@@ -382,6 +386,7 @@ contract Moloch {
             depositToken.transfer(proposal.sponsor, proposalDeposit.sub(processingReward)),
             "failed to return proposal deposit to sponsor"
         );
+        emit ProcessProposal(proposalIndex, proposal.applicant, proposal.proposer, proposal.tributeOffered, address(proposal.tributeToken), proposal.sharesRequested, didPass); 
     }
 
     function ragequit(uint256 sharesToBurn) public onlyMember {
@@ -419,7 +424,11 @@ contract Moloch {
             "withdrawal of tokens from guildBank failed"
         );
 
-        emit Ragequit(msg.sender, sharesToBurn);
+        address[] memory tokenList = new address[](_approvedTokens.length);
+        for (uint256 i=0; i < _approvedTokens.length; i++) {
+            tokenList[i] = address(approvedTokens[i]);
+        }
+        emit Ragequit(msg.sender, sharesToBurn, tokenList);
     }
 
     function cancelProposal(uint256 proposalId) public {

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -28,7 +28,7 @@ start_ganache() {
     export RUNNING_COVERAGE=true
     node_modules/.bin/ganache-cli-coverage --emitFreeLogs true --allowUnlimitedContractSize true --gasLimit 0xfffffffffff --port "$ganache_port" -m "fetch local valve black attend double eye excite planet primary install allow" > /dev/null &
   else
-    node_modules/.bin/ganache-cli -l 9500000 --port "$ganache_port" -m "fetch local valve black attend double eye excite planet primary install allow" > /dev/null &
+    node_modules/.bin/ganache-cli -l 99900000  --allowUnlimitedContractSize true --port "$ganache_port" -m "fetch local valve black attend double eye excite planet primary install allow" > /dev/null &
   fi
 
   ganache_pid=$!


### PR DESCRIPTION
### WIP

- [X] Review V1 Contracts

- [X]  Review V1 Subgrapth

- [X] Write/Review V2 Contract Events Spec (@ameensol )

- [X] Actually emit new events 

- [x] Write Tests

- [x] Tests Passing

### Proposed Changes
   **SubmitProposal**: The following functions can be used to submit new proposals need to account for new proposal types to whitelist tokens and guild kick.
                               need to know what token is used to pay tribute and if a trade is requested also need the tribute token

**function submitProposal**( address applicant, uint256 sharesRequested, uint256 tributeOffered, address tributeToken,  uint256 paymentRequested, address paymentToken, string memory details)
**function submitWhitelistProposal**(address tokenToWhitelist, string memory details) public 
**function submitGuildKickProposal**(address memberToKick, string memory details) public

**event SubmitProposal**(uint256 proposalIndex, address indexed delegateKey, address indexed memberAddress, address indexed applicant, uint256 tributeOffered, address tributeToken, uint256 sharesRequested, uint256 paymentRequested, address paymentToken);

--------------------------------------------------------------------------------------------------

**SponsorProposal:** The starting period  of a proposal is now set by the sponsorProposal function call. Proposals are not put in the proposal queue until it has been sponsored ( breaking the previous invariant (proposalIndex == Queue Index)  so need to fire an event here to set it otherwise graphprotocol can’t event source the starting period or link the proposalIndex to the the proposalQueueIndex

**function sponsorProposal**(uint256 proposalId)

**event SponsorProposal**(uint256 proposalIndex, uint256 proposalQueueIndex, uint256 startingPeriod);


--------------------------------------------------------------------------------------------------

**SubmitVote:**  Proposal index is a misnomer as it actually reffers to to the proposal queue index which holds the actual index for the proposal in the Proposals[] object.
                        this happens because Proposals are not put in the proposal queue until it has been sponsored now( breaking the previous invariant (proposalIndex == Queue Index) 

**function submitVote**(uint256 proposalIndex, uint8 uintVote)

**SubmitVote**(uint256 indexed proposalQueueIndex, address indexed delegateKey, address indexed memberAddress, uint8 uintVote);

--------------------------------------------------------------------------------------------------

**ProcessProposal**:  Proposal index is a misnomer as it actually reffers to to the proposal queue index which holds the actual index for the proposal in the Proposals[] object. This happens because Proposals are not put in the proposal queue until it has been sponsored now( breaking the previous invariant (proposalIndex == Queue Index)

**ProcessProposal**(uint256 indexed proposalQueueIndex, address indexed applicant, address indexed memberAddress, uint256 tributeOffered, address tributeToken, uint256 sharesRequested, bool didPass);

--------------------------------------------------------------------------------------------------

**Ragequit**:  Ragequitting now entails sending out a percentage of all approved token balances commesurate to the number of shares owned. if you safeRageQuit you can further chose
                   the tokens that you are paid out in, need this information to keep all token balances up to date, since the approved tokens can change (only appended to) should add the tokenList 
                   for event sourcing

**Ragequit**(address indexed memberAddress, uint256 sharesToBurn,  uint256[] tokenList);

--------------------------------------------------------------------------------------------------

**CancelProposal**: LGTM

**CancelProposal**(uint256 indexed proposalIndex, address applicantAddress);

--------------------------------------------------------------------------------------------------

**UpdateDelegateKey**: LGTM 
**UpdateDelegateKey**(address indexed memberAddress, address newDelegateKey);

--------------------------------------------------------------------------------------------------

**SummonComplete**: LGTM
**SummonComplete**(address indexed summoner, uint256 shares);


NOTES: New event schema is in with all events changed being successfully emitted and tests passing, contract is over 24kb, --allowUnlimitedContractSize is required on ganache to test